### PR TITLE
feat(router): expose potential cached tokens on backpressure

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -335,11 +335,13 @@ impl Router {
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             } => Err(anyhow::anyhow!(
-                "Prefill router backpressure: {:?} (queued_isl_tokens={}, max={:?})",
+                "Prefill router backpressure: {:?} (queued_isl_tokens={}, max={:?}, potential_cached_tokens={:?})",
                 reason,
                 queued_isl_tokens,
-                max_queued_isl_tokens
+                max_queued_isl_tokens,
+                potential_cached_tokens
             )),
         }
     }

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -488,11 +488,13 @@ impl RouterHandles {
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             } => {
                 tracing::warn!(
                     reason = ?reason,
                     queued_isl_tokens,
                     max_queued_isl_tokens = ?max_queued_isl_tokens,
+                    potential_cached_tokens = ?potential_cached_tokens,
                     "Prefill query rejected due to router backpressure"
                 );
                 Err(QueryRouterResult::ErrBackpressure)
@@ -572,11 +574,13 @@ impl RouterHandles {
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             } => {
                 tracing::warn!(
                     reason = ?reason,
                     queued_isl_tokens,
                     max_queued_isl_tokens = ?max_queued_isl_tokens,
+                    potential_cached_tokens = ?potential_cached_tokens,
                     "Decode query rejected due to router backpressure"
                 );
                 Err(QueryRouterResult::ErrBackpressure)

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1702,25 +1702,28 @@ impl KvRouter {
                     reason,
                     queued_isl_tokens,
                     max_queued_isl_tokens,
+                    potential_cached_tokens,
                 } => {
                     // Note: Backpressure is currently treated as Unavailable and falls through
                     // to the error path. Distinguishing backpressure from regular errors in Python
                     // would require returning a structured result type instead of raising an exception,
                     // which is a breaking API change. For now, callers should treat any error from
                     // best_worker as potentially transient and implement retry logic accordingly.
-                    // The backpressure info (reason, queued_isl_tokens, max_queued_isl_tokens) is logged but
+                    // The backpressure info (reason, queued_isl_tokens, max_queued_isl_tokens, potential_cached_tokens) is logged but
                     // not exposed to Python callers.
                     tracing::warn!(
                         reason = ?reason,
                         queued_isl_tokens,
                         max_queued_isl_tokens = ?max_queued_isl_tokens,
+                        potential_cached_tokens = ?potential_cached_tokens,
                         "Router backpressure - treating as unavailable"
                     );
                     return Err(to_pyerr(anyhow::anyhow!(
-                        "router backpressure: {:?} (queued_isl_tokens={}, max_queued_isl_tokens={:?})",
+                        "router backpressure: {:?} (queued_isl_tokens={}, max_queued_isl_tokens={:?}, potential_cached_tokens={:?})",
                         reason,
                         queued_isl_tokens,
-                        max_queued_isl_tokens
+                        max_queued_isl_tokens,
+                        potential_cached_tokens
                     )));
                 }
             };

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -514,6 +514,8 @@ pub enum RouterResponse {
         queued_isl_tokens: usize,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         max_queued_isl_tokens: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        potential_cached_tokens: Option<usize>,
     },
     PrefillMarked {
         success: bool,
@@ -1866,6 +1868,21 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&load).unwrap(),
             r#"{"worker_id":1,"dp_rank":0,"potential_prefill_tokens":16,"potential_decode_blocks":4,"active_requests":2}"#
+        );
+    }
+
+    #[test]
+    fn test_router_response_backpressure_potential_cached_tokens() {
+        let response = RouterResponse::Backpressure {
+            reason: RouterBackpressureReason::MaxQueuedIslTokensExceeded,
+            queued_isl_tokens: 512,
+            max_queued_isl_tokens: Some(1024),
+            potential_cached_tokens: Some(384),
+        };
+
+        assert_eq!(
+            serde_json::to_string(&response).unwrap(),
+            r#"{"method":"backpressure","reason":"max_queued_isl_tokens_exceeded","queued_isl_tokens":512,"max_queued_isl_tokens":1024,"potential_cached_tokens":384}"#
         );
     }
 }

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -439,10 +439,13 @@ impl<
                 if let Some(max_isl_tokens) = self.tier_cap_for_request(&request)
                     && pending_isl_tokens >= max_isl_tokens
                 {
+                    let potential_cached_tokens =
+                        self.best_possible_cached_tokens_for_request(&request);
                     request.respond(Err(KvSchedulerError::Backpressure {
                         reason: RouterBackpressureReason::MaxQueuedIslTokensExceeded,
                         queued_isl_tokens: pending_isl_tokens,
                         max_queued_isl_tokens: Some(max_isl_tokens),
+                        potential_cached_tokens,
                     }));
                     return;
                 }
@@ -718,6 +721,19 @@ impl<
         let worker_count = workers.len();
         self.queue_depth_tiers
             .cap_for(cache_miss_tokens, worker_count)
+    }
+
+    fn best_possible_cached_tokens_for_request(
+        &self,
+        request: &SchedulingRequest,
+    ) -> Option<usize> {
+        let workers = self.workers_with_configs.borrow();
+        let ctx = SchedulingContext::new(request, &workers);
+        Some(
+            request
+                .isl_tokens
+                .saturating_sub(ctx.best_effective_prefill_tokens()),
+        )
     }
 
     /// Check if all eligible workers are prefill-busy based on threshold.
@@ -1630,6 +1646,7 @@ mod tests {
                     reason: RouterBackpressureReason::MaxQueuedIslTokensExceeded,
                     queued_isl_tokens: 512,
                     max_queued_isl_tokens: Some(512),
+                    potential_cached_tokens: Some(0),
                 })
             ),
             "expected backpressure when queue is full, got {resp3:?}"
@@ -1679,9 +1696,49 @@ mod tests {
                     reason: RouterBackpressureReason::MaxQueuedIslTokensExceeded,
                     queued_isl_tokens: 512,
                     max_queued_isl_tokens: Some(512),
+                    potential_cached_tokens: Some(0),
                 })
             ),
             "expensive-tier request should backpressure at depth 1, got {resp3:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backpressure_reports_potential_cached_tokens() {
+        let block_size = 16;
+        let isl = 512;
+        let tiers = RouterQueueDepthTiers::try_from(vec![RouterQueueDepthByMissingIslTier {
+            missing_cache_tokens_floor: 0,
+            max_queue_depth: isl,
+        }])
+        .unwrap();
+        let (queue, _slots, _cfg_tx) =
+            make_queue_with_sender_with_tiers(1, block_size, isl, Some(0.0), tiers, None);
+
+        let (req1, rx1) = make_request("req-1", isl);
+        queue.enqueue(req1).await;
+        let _ = rx1.await.unwrap().unwrap();
+
+        let (req2, _rx2) = make_request("req-2", isl);
+        queue.enqueue(req2).await;
+
+        let (mut req3, rx3) = make_request("req-3", isl);
+        req3.effective_cached_tokens
+            .insert(WorkerWithDpRank::new(0, 0), 384);
+        queue.enqueue(req3).await;
+
+        let resp3 = rx3.await.expect("oneshot dropped");
+        assert!(
+            matches!(
+                resp3,
+                Err(KvSchedulerError::Backpressure {
+                    reason: RouterBackpressureReason::MaxQueuedIslTokensExceeded,
+                    queued_isl_tokens: 512,
+                    max_queued_isl_tokens: Some(512),
+                    potential_cached_tokens: Some(384),
+                })
+            ),
+            "backpressure should expose potential cached tokens, got {resp3:?}"
         );
     }
 

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -37,12 +37,13 @@ pub enum KvSchedulerError {
     NoEndpoints,
 
     #[error(
-        "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
+        "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?}, potential_cached_tokens={potential_cached_tokens:?})"
     )]
     Backpressure {
         reason: RouterBackpressureReason,
         queued_isl_tokens: usize,
         max_queued_isl_tokens: Option<usize>,
+        potential_cached_tokens: Option<usize>,
     },
 
     #[error("all eligible workers are overloaded")]

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -92,6 +92,7 @@ pub enum FindBestMatchOutcome {
         reason: RouterBackpressureReason,
         queued_isl_tokens: usize,
         max_queued_isl_tokens: Option<usize>,
+        potential_cached_tokens: Option<usize>,
     },
 }
 
@@ -503,11 +504,13 @@ where
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             }) => {
                 return Ok(FindBestMatchOutcome::Backpressure {
                     reason,
                     queued_isl_tokens,
                     max_queued_isl_tokens,
+                    potential_cached_tokens,
                 });
             }
             Err(error) => return Err(map_scheduler_error(error)),
@@ -602,8 +605,9 @@ where
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             } => Err(anyhow::anyhow!(
-                "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
+                "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?}, potential_cached_tokens={potential_cached_tokens:?})"
             )),
         }
     }
@@ -1031,10 +1035,12 @@ where
                         reason,
                         queued_isl_tokens,
                         max_queued_isl_tokens,
+                        potential_cached_tokens,
                     }) => RouterResponse::Backpressure {
                         reason,
                         queued_isl_tokens,
                         max_queued_isl_tokens,
+                        potential_cached_tokens,
                     },
                     Err(error) => return Err(error),
                 }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -106,6 +106,7 @@ pub enum PrefillQueryOutcome {
         reason: RouterBackpressureReason,
         queued_isl_tokens: usize,
         max_queued_isl_tokens: Option<usize>,
+        potential_cached_tokens: Option<usize>,
     },
 }
 

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -65,10 +65,12 @@ impl PrefillRouter {
                         reason,
                         queued_isl_tokens,
                         max_queued_isl_tokens,
+                        potential_cached_tokens,
                     } => Ok(PrefillQueryOutcome::Backpressure {
                         reason,
                         queued_isl_tokens,
                         max_queued_isl_tokens,
+                        potential_cached_tokens,
                     }),
                 }
             }

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -110,10 +110,11 @@ impl KvPushRouter {
                 reason,
                 queued_isl_tokens,
                 max_queued_isl_tokens,
+                potential_cached_tokens,
             } => Err(DynamoError::builder()
                 .error_type(ErrorType::ResourceExhausted)
                 .message(format!(
-                    "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
+                    "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?}, potential_cached_tokens={potential_cached_tokens:?})"
                 ))
                 .build()
                 .into()),


### PR DESCRIPTION
## Summary
- Expose `potential_cached_tokens` on router backpressure responses so 429 handling can report the best possible cache fraction.
- Thread the optional value through scheduler errors, router outcomes, prefill outcomes, push-router errors, and Python binding logging.
- Keep routed `cached_tokens` unchanged for successful worker selections.

## Validation
- `cargo test -p dynamo-kv-router backpressure --lib`
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `cargo clippy -p dynamo-llm --no-default-features -- -D warnings`
- `cargo clippy --manifest-path lib/bindings/python/Cargo.toml --no-default-features -- -D warnings`